### PR TITLE
destination address + withdraw third party method

### DIFF
--- a/contracts/EthTokenToSmthSwaps.sol
+++ b/contracts/EthTokenToSmthSwaps.sol
@@ -12,6 +12,7 @@ contract EthTokenToSmthSwaps {
 
   struct Swap {
     address token;
+    address targetWallet;
     bytes32 secret;
     bytes20 secretHash;
     uint256 createdAt;
@@ -39,6 +40,7 @@ contract EthTokenToSmthSwaps {
 
     swaps[msg.sender][_participantAddress] = Swap(
       _token,
+      _participantAddress,
       bytes32(0),
       _secretHash,
       now,
@@ -48,10 +50,34 @@ contract EthTokenToSmthSwaps {
     CreateSwap(now);
   }
 
+  // ETH Owner creates Swap with secretHash and targetWallet
+  // ETH Owner make token deposit
+  function createSwapTarget(bytes20 _secretHash, address _participantAddress, address _targetWallet, uint256 _value, address _token) public {
+    require(_value > 0);
+    require(swaps[msg.sender][_participantAddress].balance == uint256(0));
+    require(ERC20(_token).transferFrom(msg.sender, this, _value));
+
+    swaps[msg.sender][_participantAddress] = Swap(
+      _token,
+      _targetWallet,
+      bytes32(0),
+      _secretHash,
+      now,
+      _value
+    );
+
+    CreateSwap(now);
+  }
+  
   function getBalance(address _ownerAddress) public view returns (uint256) {
     return swaps[_ownerAddress][msg.sender].balance;
   }
 
+  // Get target wallet (buyer check)
+  function getTargetWallet(address tokenOwnerAddress) public returns (address) {
+      return swaps[tokenOwnerAddress][msg.sender].targetWallet;
+  }
+  
   event Withdraw();
 
   // BTC Owner withdraw money and adds secret key to swap
@@ -67,6 +93,22 @@ contract EthTokenToSmthSwaps {
 
     swaps[_ownerAddress][msg.sender].balance = 0;
     swaps[_ownerAddress][msg.sender].secret = _secret;
+
+    Withdraw();
+  }
+  // Token Owner withdraw money when participan no money for gas and adds secret key to swap
+  // BTC Owner receive +1 reputation... may be
+  function withdrawNoMoney(bytes32 _secret, address participantAddress) public {
+    Swap memory swap = swaps[msg.sender][participantAddress];
+
+    require(swap.secretHash == ripemd160(_secret));
+    require(swap.balance > uint256(0));
+    require(swap.createdAt.add(SafeTime) > now);
+
+    ERC20(swap.token).transfer(swap.targetWallet, swap.balance);
+
+    swaps[msg.sender][participantAddress].balance = 0;
+    swaps[msg.sender][participantAddress].secret = _secret;
 
     Withdraw();
   }


### PR DESCRIPTION
Адрес назначения для токенов
метод createSwapTarget - создание свапа с адресом назначения отличным от participantAddress
метод getTargetWallet - возвращает адрес назначения - для защиты от подмены
метод withdrawNoMoney - завершение свапа продавцом